### PR TITLE
fix: improve CI output

### DIFF
--- a/examples/sf-specific/deploy.ts
+++ b/examples/sf-specific/deploy.ts
@@ -44,6 +44,7 @@ const ms = new MultiStageOutput<Data>({
       bold: true,
       get: (data): string | undefined => data?.status,
       label: 'Status',
+      onlyShowAtEndInCI: true,
       type: 'dynamic-key-value',
     },
     {
@@ -120,6 +121,22 @@ for (let i = 0; i <= 10; i++) {
 
   // eslint-disable-next-line no-await-in-loop
   await sleep(200)
+}
+
+ms.goto('Running Tests')
+const tests = 500
+for (let i = 0; i <= tests; i++) {
+  ms.updateData({
+    mdapiDeploy: {
+      numberComponentsDeployed: 10,
+      numberComponentsTotal: 10,
+      numberTestsCompleted: i,
+      numberTestsTotal: tests,
+    },
+  })
+
+  // eslint-disable-next-line no-await-in-loop
+  await sleep(10)
 }
 
 ms.updateData({status: 'Succeeded'})

--- a/src/components/stages.tsx
+++ b/src/components/stages.tsx
@@ -37,6 +37,10 @@ type Info<T extends Record<string, unknown>> = {
    * Set to `true` to prevent this key-value pair or message from being collapsed when the window is too short. Defaults to false.
    */
   neverCollapse?: boolean
+  /**
+   * Set to `true` to only show this key-value pair or message at the very of the CI output. Defaults to false.
+   */
+  onlyShowAtEndInCI?: boolean
 }
 
 export type KeyValuePair<T extends Record<string, unknown>> = Info<T> & {

--- a/src/components/stages.tsx
+++ b/src/components/stages.tsx
@@ -38,7 +38,7 @@ type Info<T extends Record<string, unknown>> = {
    */
   neverCollapse?: boolean
   /**
-   * Set to `true` to only show this key-value pair or message at the very of the CI output. Defaults to false.
+   * Set to `true` to only show this key-value pair or message at the very end of the CI output. Defaults to false.
    */
   onlyShowAtEndInCI?: boolean
 }


### PR DESCRIPTION
- add `onlyShowAtEndInCI` config prop so that consumers can choose for information to only be shown at the very end when in CI
- Don't repeat stage headers when receiving updates to stage specific infos
- Reprint stage or stage specific infos after 5 minutes (configurable with `OCLIF_CI_HEARTBEAT_FREQUENCY_MS` or `SF_CI_HEARTBEAT_FREQUENCY_MS`)
- Throttle new information every 5 seconds (configurable with `OCLIF_CI_UPDATE_FREQUENCY_MS` or `SF_CI_UPDATE_FREQUENCY_MS`)

https://github.com/forcedotcom/cli/issues/3079
@W-17060727@