### PR TITLE
feat: add `alwaysPrintInCI` option

### DIFF
--- a/examples/sf-specific/deploy.ts
+++ b/examples/sf-specific/deploy.ts
@@ -80,10 +80,20 @@ const ms = new MultiStageOutput<Data>({
         data?.mdapiDeploy?.numberTestsTotal && data?.mdapiDeploy?.numberTestsCompleted
           ? formatProgress(data?.mdapiDeploy?.numberTestsCompleted, data?.mdapiDeploy?.numberTestsTotal)
           : undefined,
-      label: 'Tests',
+      label: 'Successful',
       stage: 'Running Tests',
       type: 'dynamic-key-value',
     },
+    {
+      get: (data): string | undefined =>
+        data?.mdapiDeploy?.numberTestsTotal && data?.mdapiDeploy?.numberTestsCompleted
+          ? formatProgress(data?.mdapiDeploy?.numberTestErrors, data?.mdapiDeploy?.numberTestsTotal)
+          : undefined,
+      label: 'Failed',
+      stage: 'Running Tests',
+      type: 'dynamic-key-value',
+    },
+
     {
       get: (data): string | undefined =>
         data?.sourceMemberPolling?.original
@@ -130,6 +140,7 @@ for (let i = 0; i <= tests; i++) {
     mdapiDeploy: {
       numberComponentsDeployed: 10,
       numberComponentsTotal: 10,
+      numberTestErrors: 0,
       numberTestsCompleted: i,
       numberTestsTotal: tests,
     },

--- a/src/components/stages.tsx
+++ b/src/components/stages.tsx
@@ -41,6 +41,10 @@ type Info<T extends Record<string, unknown>> = {
    * Set to `true` to only show this key-value pair or message at the very end of the CI output. Defaults to false.
    */
   onlyShowAtEndInCI?: boolean
+  /**
+   * Set to `true` to always render this key-value pair or message in CI output (ignores throttling). Defaults to false.
+   */
+  alwaysPrintInCI?: boolean
 }
 
 export type KeyValuePair<T extends Record<string, unknown>> = Info<T> & {

--- a/src/multi-stage-output.tsx
+++ b/src/multi-stage-output.tsx
@@ -294,7 +294,7 @@ class CIMultiStageOutput<T extends Record<string, unknown>> {
 
         const formattedData = info.get ? info.get(this.data as T) : undefined
         if (!formattedData) continue
-        const key = info.type === 'message' ? formattedData : info.label
+        const key = info.type === 'message' ? formattedData : `${info.label}: ${formattedData}`
         const str = info.type === 'message' ? formattedData : `${info.label}: ${formattedData}`
 
         const lastUpdateTime = this.lastUpdateByInfo.get(key)

--- a/src/multi-stage-output.tsx
+++ b/src/multi-stage-output.tsx
@@ -294,12 +294,14 @@ class CIMultiStageOutput<T extends Record<string, unknown>> {
 
         const formattedData = info.get ? info.get(this.data as T) : undefined
         if (!formattedData) continue
-        const key = info.type === 'message' ? formattedData : `${info.label}: ${formattedData}`
+        const key = info.type === 'message' ? formattedData : info.label
         const str = info.type === 'message' ? formattedData : `${info.label}: ${formattedData}`
 
-        const lastUpdateTime = this.lastUpdateByInfo.get(key)
-        // Skip if the info has been printed before the throttle time
-        if (lastUpdateTime && Date.now() - lastUpdateTime < this.throttle && !force) continue
+        if (!info.alwaysPrintInCI) {
+          const lastUpdateTime = this.lastUpdateByInfo.get(key)
+          // Skip if the info has been printed before the throttle time
+          if (lastUpdateTime && Date.now() - lastUpdateTime < this.throttle && !force) continue
+        }
 
         const didPrint = this.maybeStdout(str, indent, force)
         if (didPrint) this.lastUpdateByInfo.set(key, Date.now())


### PR DESCRIPTION
Found this bug while working on https://github.com/salesforcecli/plugin-deploy-retrieve/pull/1215/files

Adds new `alwaysPrintInCI` option suggested here:
https://github.com/oclif/multi-stage-output/pull/76#discussion_r1884503768

it only affects CI output, if an info block sets it to true then all updates will be rendered (to avoid possible duplicates consumers need to handle that in the info block getter).

@W-17203886@
