### PR TITLE
fix: pin ink to 5.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,6 @@ updates:
       # no release for dev-deps
       prefix-development: chore(dev-deps)
     ignore:
-      - dependency-name: '@salesforce/dev-scripts'
+      - dependency-name: 'ink'
       - dependency-name: '*'
         update-types: ['version-update:semver-major']

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@types/react": "^18.3.12",
     "cli-spinners": "^2",
     "figures": "^6.1.0",
-    "ink": "^5.1.0",
+    "ink": "5.0.1",
     "react": "^18.3.1",
     "wrap-ansi": "^9.0.0"
   },


### PR DESCRIPTION
Pin ink to 5.0.1 until https://github.com/vadimdemedes/ink/issues/692 is resolved.

@W-17591915@