### PR TITLE
fix: incorrect repo property in package @W-22477677@

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "exports": {
     ".": "./lib/index.js"
   },
-  "repository": "oclif/core",
+  "repository": "oclif/multi-stage-output",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Turns out that the `repo` property in `package.json` doesn't actually point to this repository. Oops!

@W-22477677@